### PR TITLE
feat: add piano reading trainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+dist

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# PianoTrial
-A Page to train your piano sheet reading skills.
+# Treino Musical
+
+Responsive web app to practice reading piano sheet music for treble and bass clefs. Built with React, Vite and Tailwind CSS in a neomorphic style.
+
+## Setup
+
+```bash
+npm install
+npm run dev
+```
+
+If starting from scratch:
+
+```bash
+npm create vite@latest treino-musical -- --template react
+cd treino-musical
+npm i -D tailwindcss postcss autoprefixer
+npx tailwindcss init -p
+# configure content paths; add @tailwind directives to index.css
+npm run dev
+```
+
+## TODO
+- Timed sessions
+- Per-note analytics
+- Lines-vs-spaces drill
+- Interval mode

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Treino Musical</title>
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "treino-musical",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.12",
+    "postcss": "^8.4.18",
+    "tailwindcss": "^3.2.4",
+    "vite": "^5.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,80 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import Staff from './components/Staff'
+import PianoKeyboard from './components/PianoKeyboard'
+import { Card, Button, Toggle } from './components/NeoUI'
+import { randomNoteInRange, LETTERS, LETTERS_PT, toMidi } from './lib/music'
+
+export default function App(){
+  const [clef, setClef] = useState('treble')
+  const [accidentals, setAccidentals] = useState(true)
+  const [ledger, setLedger] = useState(false)
+  const [locale, setLocale] = useState('EN')
+  const [mode, setMode] = useState('letters')
+  const [hint, setHint] = useState(true)
+  const [score, setScore] = useState({hit:0, miss:0})
+  const [note, setNote] = useState(() => randomNoteInRange('treble', accidentals, ledger))
+  const [feedback, setFeedback] = useState(null)
+
+  const nextNote = useCallback(() => {
+    setNote(randomNoteInRange(clef, accidentals, ledger))
+  }, [clef, accidentals, ledger])
+
+  const handleAnswer = useCallback((correct) => {
+    setFeedback(correct ? 'hit' : 'miss')
+    setScore(s => ({hit: s.hit + (correct?1:0), miss: s.miss + (correct?0:1)}))
+    setTimeout(() => {
+      setFeedback(null)
+      nextNote()
+    }, 500)
+  }, [nextNote])
+
+  const handleLetter = (letter) => handleAnswer(letter === note.letter)
+  const handleKey = (midi) => handleAnswer(midi === toMidi(note))
+
+  useEffect(() => { nextNote() }, [clef, accidentals, ledger])
+
+  useEffect(() => {
+    const handler = e => {
+      if(e.code === 'Space'){ nextNote(); e.preventDefault() }
+      if(e.key === '1') setClef('treble')
+      if(e.key === '2') setClef('bass')
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [nextNote])
+
+  const names = locale === 'PT' ? LETTERS_PT : LETTERS
+
+  return (
+    <div className="min-h-screen bg-gray-100 text-gray-800 flex flex-col items-center p-2">
+      <header className="text-2xl font-bold mb-2">Treino Musical</header>
+      <Card className="w-full max-w-md mb-2 flex flex-wrap justify-center">
+        <Toggle label="♯/♭" active={accidentals} onToggle={() => setAccidentals(a=>!a)} />
+        <Toggle label="Ledger" active={ledger} onToggle={() => setLedger(l=>!l)} />
+        <Toggle label="𝄞" active={clef==='treble'} onToggle={() => setClef('treble')} />
+        <Toggle label="𝄢" active={clef==='bass'} onToggle={() => setClef('bass')} />
+        <Toggle label="PT" active={locale==='PT'} onToggle={() => setLocale(locale==='EN'?'PT':'EN')} />
+        <Toggle label={mode==='letters'? 'Letters':'Piano'} active onToggle={() => setMode(m=>m==='letters'?'piano':'letters')} />
+        <Toggle label="Hint" active={hint} onToggle={() => setHint(h=>!h)} />
+      </Card>
+      <Card className="w-full max-w-md mb-2 text-center">
+        <div>✅ {score.hit} / ❌ {score.miss}</div>
+      </Card>
+      <Card className="w-full max-w-md mb-2">
+        <Staff pitch={note} clef={clef} locale={locale} showHint={hint} />
+        {feedback && <div className="text-center mt-2 text-xl">{feedback==='hit'?'✔':'✖'}</div>}
+      </Card>
+      <Card className="w-full max-w-md mb-4 flex justify-center">
+        {mode==='letters' ? (
+          <div className="flex flex-wrap justify-center">
+            {names.map((n,i) => (
+              <Button key={n} onClick={() => handleLetter(LETTERS[i])} ariaLabel={n}>{n}</Button>
+            ))}
+          </div>
+        ) : (
+          <PianoKeyboard onPress={handleKey} />
+        )}
+      </Card>
+    </div>
+  )
+}

--- a/src/components/NeoUI.jsx
+++ b/src/components/NeoUI.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+const base = 'bg-gray-100 rounded-xl shadow-[5px_5px_10px_#d1d5db,-5px_-5px_10px_#ffffff]'
+const pressed = 'shadow-inner'
+
+export function Card({children, className=''}){
+  return <div className={`${base} p-4 ${className}`}>{children}</div>
+}
+
+export function Button({children, onClick, pressed: isPressed, ariaLabel}){
+  return (
+    <button
+      aria-pressed={isPressed}
+      aria-label={ariaLabel}
+      onClick={onClick}
+      className={`${base} px-3 py-2 m-1 focus:outline-none focus:ring-2 focus:ring-blue-500 active:shadow-inner ${isPressed?pressed:''}`}
+    >
+      {children}
+    </button>
+  )
+}
+
+export function Toggle({label, active, onToggle}){
+  return (
+    <Button ariaLabel={label} onClick={onToggle} pressed={active}>
+      <span className={active?'font-bold':''}>{label}</span>
+    </Button>
+  )
+}

--- a/src/components/PianoKeyboard.jsx
+++ b/src/components/PianoKeyboard.jsx
@@ -1,0 +1,53 @@
+import React, { useMemo } from 'react'
+import { toMidi } from '../lib/music'
+
+// Simple rectangular 2-octave piano keyboard (C3-B4)
+export default function PianoKeyboard({ onPress }) {
+  const { whiteKeys, blackKeys } = useMemo(() => {
+    const whites = []
+    const letters = ['C','D','E','F','G','A','B']
+    let octave = 3
+    for (let i = 0; i < 14; i++) {
+      const letter = letters[i % 7]
+      if (letter === 'C' && i > 0 && i % 7 === 0) octave++
+      whites.push({ midi: toMidi({letter, octave, acc:0}), letter, octave })
+    }
+    const blacks = [
+      { midi: toMidi({letter:'C',octave:3,acc:1}), left:3.5 },
+      { midi: toMidi({letter:'D',octave:3,acc:1}), left:10.7 },
+      { midi: toMidi({letter:'F',octave:3,acc:1}), left:25 },
+      { midi: toMidi({letter:'G',octave:3,acc:1}), left:32.1 },
+      { midi: toMidi({letter:'A',octave:3,acc:1}), left:39.3 },
+      { midi: toMidi({letter:'C',octave:4,acc:1}), left:53.6 },
+      { midi: toMidi({letter:'D',octave:4,acc:1}), left:60.7 },
+      { midi: toMidi({letter:'F',octave:4,acc:1}), left:75 },
+      { midi: toMidi({letter:'G',octave:4,acc:1}), left:82.1 },
+      { midi: toMidi({letter:'A',octave:4,acc:1}), left:89.3 },
+    ]
+    return { whiteKeys: whites, blackKeys: blacks }
+  }, [])
+
+  return (
+    <div className="relative w-full h-32 select-none">
+      <div className="flex h-full">
+        {whiteKeys.map((k,i) => (
+          <button
+            key={k.midi}
+            onClick={() => onPress(k.midi)}
+            aria-label={`${k.letter}${k.octave}`}
+            className="flex-1 border mx-px bg-gray-100 rounded-b-xl active:shadow-inner focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        ))}
+      </div>
+      {blackKeys.map(b => (
+        <button
+          key={b.midi}
+          onClick={() => onPress(b.midi)}
+          aria-label={`black key ${b.midi}`}
+          style={{left:`${b.left}%`, width:'5%'}}
+          className="absolute h-20 -top-0 bg-gray-700 rounded-b-md active:shadow-inner focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/Staff.jsx
+++ b/src/components/Staff.jsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { relIndexTreble, relIndexBass, formatPitch } from '../lib/music'
+
+// SVG staff rendering. Computes vertical placement based on relative index.
+export default function Staff({ pitch, clef, showHint=true, locale='EN' }){
+  const rel = clef === 'treble' ? relIndexTreble(pitch) : relIndexBass(pitch)
+  const lineGap = 10
+  const staffTop = 20
+  const y = staffTop + (4 - rel) * (lineGap/2)
+
+  const ledger = []
+  if (rel < 0) {
+    for (let i = rel; i <= -1; i++) if (i % 2 === 0) ledger.push(i)
+  } else if (rel > 8) {
+    for (let i = rel; i >= 9; i--) if (i % 2 === 0) ledger.push(i)
+  }
+
+  const stemUp = rel < 6
+  const noteX = 100
+  const stemLen = 30
+  const acc = pitch.acc === -1 ? '♭' : pitch.acc === 1 ? '♯' : ''
+
+  return (
+    <div className="flex flex-col items-center">
+      <svg viewBox="0 0 200 100" className="w-full h-32">
+        {[0,1,2,3,4].map(i => (
+          <line key={i} x1="20" x2="180" y1={staffTop + i*lineGap} y2={staffTop + i*lineGap} stroke="black" />
+        ))}
+        <text x="35" y={staffTop + lineGap*3} fontSize="30">{clef==='treble'?'𝄞':'𝄢'}</text>
+        {ledger.map(l => (
+          <line key={l} x1="80" x2="120" y1={staffTop + (4 - l)*(lineGap/2)} y2={staffTop + (4 - l)*(lineGap/2)} stroke="black" />
+        ))}
+        {acc && <text x="85" y={y+5} fontSize="20">{acc}</text>}
+        <ellipse cx={noteX} cy={y} rx="6" ry="4" fill="black" />
+        {stemUp ? (
+          <line x1={noteX+6} y1={y} x2={noteX+6} y2={y - stemLen} stroke="black" />
+        ) : (
+          <line x1={noteX-6} y1={y} x2={noteX-6} y2={y + stemLen} stroke="black" />
+        )}
+      </svg>
+      {showHint && <div className="text-sm mt-1">{formatPitch(pitch, locale)}</div>}
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, #root {
+  height: 100%;
+}

--- a/src/lib/music.js
+++ b/src/lib/music.js
@@ -1,0 +1,81 @@
+// Music theory helpers for pitch modeling and random note generation.
+// Pitch: { letter: 'C'|'D'|'E'|'F'|'G'|'A'|'B', octave: number, acc: -1|0|1 }
+// MIDI mapping uses C4 = 60.
+
+export const LETTERS = ['C','D','E','F','G','A','B']
+export const LETTERS_PT = ['Dó','Ré','Mi','Fá','Sol','Lá','Si']
+
+// Map letter to semitone offset from C within octave
+const LETTER_TO_SEMITONE = {C:0, D:2, E:4, F:5, G:7, A:9, B:11}
+
+// Map letter to diatonic index within octave (0..6)
+const LETTER_TO_INDEX = {C:0, D:1, E:2, F:3, G:4, A:5, B:6}
+
+// Convert pitch to a diatonic index. Each letter step counts as 1.
+export function diatonicIndex(p){
+  return p.octave * 7 + LETTER_TO_INDEX[p.letter]
+}
+
+// Convert pitch to MIDI number (C4 = 60)
+export function toMidi(p){
+  return (p.octave - 4) * 12 + 60 + LETTER_TO_SEMITONE[p.letter] + p.acc
+}
+
+// Helpers to compute staff relative index
+const TREBLE_BASE = diatonicIndex({letter:'E',octave:4,acc:0}) // bottom line E4
+const BASS_BASE = diatonicIndex({letter:'G',octave:2,acc:0})   // bottom line G2
+
+export function relIndexTreble(p){
+  return diatonicIndex(p) - TREBLE_BASE
+}
+export function relIndexBass(p){
+  return diatonicIndex(p) - BASS_BASE
+}
+
+// Ranges for training
+export const RANGES = {
+  treble: { low: {letter:'C', octave:4, acc:0}, high: {letter:'A', octave:5, acc:0} },
+  bass:   { low: {letter:'E', octave:2, acc:0}, high: {letter:'C', octave:4, acc:0} },
+}
+
+function clone(p){
+  return {letter:p.letter, octave:p.octave, acc:p.acc || 0}
+}
+
+function stepFrom(start, steps){
+  // Move diatonically by steps from start and return new pitch
+  const total = diatonicIndex(start) + steps
+  const octave = Math.floor(total / 7)
+  const letter = LETTERS[total % 7]
+  return {letter, octave, acc:0}
+}
+
+export function randomNoteInRange(clef, allowAcc, extended){
+  const range = RANGES[clef]
+  let low = clone(range.low)
+  let high = clone(range.high)
+  if(extended){
+    low = stepFrom(low, -4)
+    high = stepFrom(high, 4)
+  }
+  const lowIndex = diatonicIndex(low)
+  const highIndex = diatonicIndex(high)
+  const randIndex = Math.floor(Math.random() * (highIndex - lowIndex + 1)) + lowIndex
+  const letter = LETTERS[randIndex % 7]
+  const octave = Math.floor(randIndex / 7)
+  let acc = 0
+  if(allowAcc){
+    const opts = [-1,0,1]
+    acc = opts[Math.floor(Math.random()*3)]
+  }
+  return {letter, octave, acc}
+}
+
+export function formatPitch(p, locale='EN'){
+  const names = locale==='PT'?LETTERS_PT:LETTERS
+  const letterName = names[LETTERS.indexOf(p.letter)]
+  let accSym = ''
+  if(p.acc === -1) accSym = '♭'
+  if(p.acc === 1) accSym = '♯'
+  return `${letterName}${accSym}${p.octave}`
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{js,jsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- set up Vite + React + Tailwind project
- implement music theory helpers, neomorphic UI components, staff and piano keyboard
- add score tracking, options, and responsive layout

## Testing
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run build` *(fails: vite not found; dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68969a6eba008332bdc6327b6c02a2e5